### PR TITLE
Updated README.doc to include step to install the next framework components via yarn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Create a `.env` file in the root of the project and add the following:
 DEEPGRAM_API_KEY=<your-deepgram-api-key>
 ```
 
-> **_Note ℹ️_**: When creating the API Key make sure to select "Member" as the role and not "Default" so that the API Key has permissions to create new API Keys.
+> **_Note_ ℹ️**: When creating the API Key make sure to select "Member" as the role and not "Default" so that the API Key has permissions to create new API Keys.
 
 See `sample.env.local` for more details.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Table of contents:
 
 - [Node v20](https://nodejs.org/en/download/) or higher (though I recommend installing it through [nvm](https://github.com/nvm-sh/nvm#installing-and-updating))
 - [yarn](https://classic.yarnpkg.com/en/docs/install)
+- [Next JS](https://nextjs.org/docs/app/getting-started/installation) Although the docs use npm, you can easily switch the commands to Yarn. For example:
+
+```
+# Install Next.js, React, and React DOM using Yarn
+yarn add next react react-dom
+```
+
+Then confirm "dev": "next dev" is in your scripts section in package.json.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Create a `.env` file in the root of the project and add the following:
 DEEPGRAM_API_KEY=<your-deepgram-api-key>
 ```
 
-Note: When creating the API Key make sure to select "Member" as the role and not "Default" so that the API Key has permissions to create new API Keys.
+> **_Note ℹ️_**: When creating the API Key make sure to select "Member" as the role and not "Default" so that the API Key has permissions to create new API Keys.
 
 See `sample.env.local` for more details.
 


### PR DESCRIPTION
I ran into the issue where I tried doing this from scratch and didn't have next installed so I added a prereq step which links to the next docs but points out you can use yarn to perform the install.