### PR TITLE
Migrate to the v1 voice agent API

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -44,7 +44,7 @@ export const App = ({
     startMicrophone,
   } = useMicrophone();
   const { socket, connectToDeepgram, socketState, rateLimited } = useDeepgram();
-  const { voice, instructions, applyParamsToConfig } = useStsQueryParams();
+  const { voice, prompt, applyParamsToConfig } = useStsQueryParams();
   const audioContext = useRef(null);
   const agentVoiceAnalyser = useRef(null);
   const userVoiceAnalyser = useRef(null);
@@ -52,7 +52,7 @@ export const App = ({
   const [data, setData] = useState();
   const [isInitialized, setIsInitialized] = useState(requiresUserActionToInitialize ? false : null);
   const previousVoice = usePrevious(voice);
-  const previousInstructions = usePrevious(instructions);
+  const previousPrompt = usePrevious(prompt);
   const scheduledAudioSources = useRef([]);
   const pathname = usePathname();
 
@@ -254,19 +254,24 @@ export const App = ({
     if (previousVoice && previousVoice !== voice && socket && socketState === 1) {
       sendSocketMessage(socket, {
         type: "UpdateSpeak",
-        model: voice,
+        speak: {
+          provider: {
+            type: "deepgram",
+            model: voice,
+          },
+        },
       });
     }
   }, [voice, socket, socketState, previousVoice]);
 
   useEffect(() => {
-    if (previousInstructions !== instructions && socket && socketState === 1) {
+    if (previousPrompt !== prompt && socket && socketState === 1) {
       sendSocketMessage(socket, {
-        type: "UpdateInstructions",
-        instructions: `${defaultStsConfig.agent.think.instructions}\n${instructions}`,
+        type: "UpdatePrompt",
+        prompt: `${defaultStsConfig.agent.think.prompt}\n${prompt}`,
       });
     }
-  }, [defaultStsConfig, previousInstructions, instructions, socket, socketState]);
+  }, [defaultStsConfig, previousPrompt, prompt, socket, socketState]);
 
   /**
    * Manage responses to incoming data from WebSocket.

--- a/app/components/InstructionInput.tsx
+++ b/app/components/InstructionInput.tsx
@@ -7,15 +7,15 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const InstructionInput: FC<Props> = ({ focusOnMount = false, ...rest }) => {
-  const { instructions, updateInstructionsUrlParam } = useStsQueryParams();
-  const [text, setText] = useState(instructions);
+  const { prompt, updatePromptUrlParam } = useStsQueryParams();
+  const [text, setText] = useState(prompt);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const textRef = useRef(text);
   const autofocus = useRef(focusOnMount);
 
   const handleBlur = () => {
-    if (text !== instructions) {
-      updateInstructionsUrlParam(text);
+    if (text !== prompt) {
+      updatePromptUrlParam(text);
     }
   };
 
@@ -31,9 +31,9 @@ const InstructionInput: FC<Props> = ({ focusOnMount = false, ...rest }) => {
 
   useEffect(() => {
     return () => {
-      updateInstructionsUrlParam(textRef.current);
+      updatePromptUrlParam(textRef.current);
     };
-  }, [updateInstructionsUrlParam]);
+  }, [updatePromptUrlParam]);
 
   return (
     <div {...rest}>
@@ -42,8 +42,8 @@ const InstructionInput: FC<Props> = ({ focusOnMount = false, ...rest }) => {
           <PencilIcon />
           Prompt
         </div>
-        {instructions && (
-          <div className="text-xs text-gray-450 mt-3">{instructions && "* Prompt is user-set"}</div>
+        {prompt && (
+          <div className="text-xs text-gray-450 mt-3">{prompt && "* Prompt is user-set"}</div>
         )}
         <textarea
           ref={inputRef}

--- a/app/components/MobileMenu.tsx
+++ b/app/components/MobileMenu.tsx
@@ -23,7 +23,7 @@ enum Expansion {
 const { Closed, Opening, Open, Closing } = Expansion;
 
 const MobileMenu: FC<Props> = ({ hideInstructionInput, className }) => {
-  const { instructions } = useStsQueryParams();
+  const { prompt } = useStsQueryParams();
   const [expansion, setExpansion] = useState<Expansion>(Closed);
   const closeButton = useRef<HTMLButtonElement>(null);
 
@@ -47,9 +47,7 @@ const MobileMenu: FC<Props> = ({ hideInstructionInput, className }) => {
         onClick={() => setExpansion(Opening)}
       >
         <BarsIcon />
-        {instructions && (
-          <span className="absolute right-2 top-1 text-sm text-green-spring">*</span>
-        )}
+        {prompt && <span className="absolute right-2 top-1 text-sm text-green-spring">*</span>}
       </button>
       {expansion !== Closed && (
         <PopupBody onExit={() => setExpansion(Closing)}>

--- a/app/context/DeepgramContextProvider.js
+++ b/app/context/DeepgramContextProvider.js
@@ -23,7 +23,7 @@ const DeepgramContextProvider = ({ children }) => {
 
     setSocketState(0); // connecting
 
-    const newSocket = new WebSocket("wss://agent.deepgram.com/agent", [
+    const newSocket = new WebSocket("wss://agent.deepgram.com/v1/agent/converse", [
       "token",
       await getApiKey(),
     ]);

--- a/app/hooks/UseStsQueryParams.tsx
+++ b/app/hooks/UseStsQueryParams.tsx
@@ -9,50 +9,47 @@ export const useStsQueryParams = () => {
 
   const [params, setParams] = useState<{
     voice: string;
-    instructions: string | null;
-    provider: string | null;
-    model: string | null;
-    temp: string | null;
-    rep_penalty: string | null;
+    prompt: string | null;
+    think_provider: string | null;
+    think_model: string | null;
   }>({
     voice: searchParams.get("voice") || defaultVoice.canonical_name,
-    instructions: searchParams.get("instructions"),
-    provider: searchParams.get("provider"),
-    model: searchParams.get("model"),
-    temp: searchParams.get("temp"),
-    rep_penalty: searchParams.get("rep_penalty"),
+    prompt: searchParams.get("prompt"),
+    think_provider: searchParams.get("think_provider"),
+    think_model: searchParams.get("think_model"),
   });
 
   useEffect(() => {
     setParams({
       voice: searchParams.get("voice") || defaultVoice.canonical_name,
-      instructions: searchParams.get("instructions"),
-      provider: searchParams.get("provider"),
-      model: searchParams.get("model"),
-      temp: searchParams.get("temp"),
-      rep_penalty: searchParams.get("rep_penalty"),
+      prompt: searchParams.get("prompt"),
+      think_provider: searchParams.get("think_provider"),
+      think_model: searchParams.get("think_model"),
     });
   }, [searchParams]);
 
   const applyParamsToConfig = useCallback(
     (config: StsConfig) => {
-      const { voice, instructions, provider, model, temp, rep_penalty } = params;
+      const { voice, prompt, think_provider, think_model } = params;
+
       return {
         ...config,
         agent: {
           ...config.agent,
           think: {
             ...config.agent.think,
-            ...(provider && model && { provider: { type: provider }, model }),
-            ...(instructions && {
-              instructions: `${config.agent.think.instructions}\n${instructions}`,
+            ...(think_provider &&
+              think_model && { provider: { type: think_provider, model: think_model } }),
+            ...(prompt && {
+              prompt: `${config.agent.think.prompt}\n${prompt}`,
             }),
           },
           speak: {
             ...config.agent.speak,
-            ...(voice && { model: voice }),
-            ...(temp && { temp: parseFloat(temp) }),
-            ...(rep_penalty && { rep_penalty: parseFloat(rep_penalty) }),
+            provider: {
+              type: "deepgram",
+              ...(voice ? { model: voice } : { model: config.agent.speak.provider.model }),
+            },
           },
         },
       };
@@ -73,8 +70,8 @@ export const useStsQueryParams = () => {
     [router],
   );
 
-  const memoizedUpdateInstructionsUrlParam = useCallback(
-    (text: string | null) => updateUrlParam("instructions", text),
+  const memoizedUpdatePromptUrlParam = useCallback(
+    (text: string | null) => updateUrlParam("prompt", text),
     [updateUrlParam],
   );
 
@@ -86,7 +83,7 @@ export const useStsQueryParams = () => {
   return {
     ...params,
     applyParamsToConfig,
-    updateInstructionsUrlParam: memoizedUpdateInstructionsUrlParam,
+    updatePromptUrlParam: memoizedUpdatePromptUrlParam,
     updateVoiceUrlParam: memoizedUpdateVoiceUrlParam,
   };
 };

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -13,16 +13,16 @@ const audioConfig: AudioConfig = {
 };
 
 const baseConfig = {
-  type: "SettingsConfiguration",
+  type: "Settings" as const,
   audio: audioConfig,
   agent: {
-    listen: { model: "nova-2" },
-    speak: { model: "aura-asteria-en" },
+    listen: { provider: { type: "deepgram" as const, model: "nova-3" } },
+    speak: { provider: { type: "deepgram" as const, model: "aura-asteria-en" } },
     think: {
-      provider: { type: "open_ai" },
-      model: "gpt-4o",
+      provider: { type: "open_ai" as const, model: "gpt-4o" },
     },
   },
+  experimental: true,
 };
 
 export const stsConfig: StsConfig = {
@@ -31,8 +31,7 @@ export const stsConfig: StsConfig = {
     ...baseConfig.agent,
     think: {
       ...baseConfig.agent.think,
-      provider: { type: "open_ai", fallback_to_groq: true },
-      instructions: `
+      prompt: `
                 ## Base instructions
                 You are a helpful voice assistant made by Deepgram's engineers.
                 Respond in a friendly, human, conversational manner.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,16 +26,14 @@ import { useDeepgram } from "./context/DeepgramContextProvider";
 import BehindTheScenes from "./components/BehindTheScenes";
 
 const DesktopMenuItems = () => {
-  const { instructions } = useStsQueryParams();
+  const { prompt } = useStsQueryParams();
   return (
     <>
       <PopupButton
         buttonIcon={<PencilIcon />}
-        buttonText={
-          <span>Prompt {instructions && <span className="text-green-spring">*</span>}</span>
-        }
+        buttonText={<span>Prompt {prompt && <span className="text-green-spring">*</span>}</span>}
         popupContent={<InstructionInput className="w-96" focusOnMount />}
-        tooltipText={instructions ? "Using your custom prompt. Click to edit." : null}
+        tooltipText={prompt ? "Using your custom prompt. Click to edit." : null}
       />
     </>
   );

--- a/app/utils/deepgramUtils.ts
+++ b/app/utils/deepgramUtils.ts
@@ -31,45 +31,41 @@ export interface AudioConfig {
     encoding: string;
     sample_rate: number;
     container?: string;
-    buffer_size?: number;
   };
 }
 
 export interface AgentConfig {
-  listen: { model: string };
-  speak: {
-    model: string;
-    temp?: number;
-    rep_penalty?: number;
-  };
+  listen: { provider: { type: "deepgram"; model: string } };
   think: {
-    provider: { type: string; fallback_to_groq?: boolean };
-    model: string;
-    instructions: string;
+    provider: { type: string; model: string };
+    prompt: string;
     functions?: LlmFunction[];
   };
+  speak: SpeakConfig;
+  greeting?: string;
 }
 
-export interface ContextConfig {
-  messages: { role: string; content: string }[];
-  replay: boolean;
+export interface SpeakConfig {
+  provider: { type: "deepgram"; model: string };
 }
 
 export interface StsConfig {
-  type: string;
+  type: "Settings";
   audio: AudioConfig;
   agent: AgentConfig;
-  context?: ContextConfig;
+  language?: string;
+  experimental?: boolean;
 }
 
 export interface LlmFunction {
   name: string;
   description: string;
-  url: string;
-  method: string;
-  headers: Header[];
-  key?: string;
   parameters: LlmParameterObject | Record<string, never>;
+  endpoint: {
+    url: string;
+    headers: Record<string, string>;
+    method: string;
+  };
 }
 
 export type LlmParameter = LlmParameterScalar | LlmParameterObject;
@@ -89,11 +85,6 @@ export interface LlmParameterScalar extends LlmParameterBase {
   type: "string" | "integer";
 }
 
-export interface Header {
-  key: string;
-  value: string;
-}
-
 export interface Voice {
   name: string;
   canonical_name: string;
@@ -107,9 +98,9 @@ export interface Voice {
 }
 
 export type DGMessage =
-  | { type: "SettingsConfiguration"; audio: AudioConfig; agent: AgentConfig }
-  | { type: "UpdateInstructions"; instructions: string }
-  | { type: "UpdateSpeak"; model: string }
+  | { type: "Settings"; audio: AudioConfig; agent: AgentConfig }
+  | { type: "UpdatePrompt"; prompt: string }
+  | { type: "UpdateSpeak"; speak: SpeakConfig }
   | { type: "KeepAlive" };
 
 export const withBasePath = (path: string): string => {


### PR DESCRIPTION
This PR points the demo to the v1 API at `agent.deepgram.com/v1/agent/converse` instead of the v0 API at `agent.deepgram.com/agent`.

# Test Plan

- Talked to the agent and verified that the correct events were appearing the backstage view.
- Verified that I could update the voice mid-conversation by clicking the voice icons in the top right.
- Verified that I could pass the 4 configurable settings via query params, and these took effect as intended: `?voice=aura-arcas-en&prompt=say+howdy+a+lot&think_provider=anthropic&think_model=claude-3-haiku-20240307`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210190833640505